### PR TITLE
Novos Endpoint e DTOs para "Recipients"

### DIFF
--- a/src/DTOs/Recipients/AddressDTO.php
+++ b/src/DTOs/Recipients/AddressDTO.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class AddressDTO
+{
+    public function __construct(
+        public readonly string $street,
+        public readonly string $complementary,
+        public readonly string $street_number,
+        public readonly string $neighborhood,
+        public readonly string $city,
+        public readonly string $state,
+        public readonly string $zip_code,
+        public readonly string $reference_point,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            street: $data['street'],
+            complementary: $data['complementary'],
+            street_number: $data['street_number'],
+            neighborhood: $data['neighborhood'],
+            city: $data['city'],
+            state: $data['state'],
+            zip_code: $data['zip_code'],
+            reference_point: $data['reference_point'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'street' => $this->street,
+            'complementary' => $this->complementary,
+            'street_number' => $this->street_number,
+            'neighborhood' => $this->neighborhood,
+            'city' => $this->city,
+            'state' => $this->state,
+            'zip_code' => $this->zip_code,
+            'reference_point' => $this->reference_point,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
+++ b/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class AutomaticAnticipationSettingsDTO
+{
+    public function __construct(
+        public readonly bool $enabled,
+        public readonly string $type,
+        public readonly string $volume_percentage,
+        public readonly ?string $delay,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            enabled: filter_var($data['enabled'], FILTER_VALIDATE_BOOLEAN),
+            type: $data['type'],
+            volume_percentage: $data['volume_percentage'],
+            delay: $data['delay'] !== 'null' ? $data['delay'] : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'enabled' => $this->enabled,
+            'type' => $this->type,
+            'volume_percentage' => $this->volume_percentage,
+            'delay' => $this->delay,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/BankAccountDTO.php
+++ b/src/DTOs/Recipients/BankAccountDTO.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class BankAccountDTO
+{
+    public function __construct(
+        public readonly string $holder_name,
+        public readonly string $holder_type,
+        public readonly string $holder_document,
+        public readonly string $bank,
+        public readonly string $branch_number,
+        public readonly string $branch_check_digit,
+        public readonly string $account_number,
+        public readonly string $account_check_digit,
+        public readonly string $type,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            holder_name: $data['holder_name'],
+            holder_type: $data['holder_type'],
+            holder_document: $data['holder_document'],
+            bank: $data['bank'],
+            branch_number: $data['branch_number'],
+            branch_check_digit: $data['branch_check_digit'],
+            account_number: $data['account_number'],
+            account_check_digit: $data['account_check_digit'],
+            type: $data['type'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'holder_name' => $this->holder_name,
+            'holder_type' => $this->holder_type,
+            'holder_document' => $this->holder_document,
+            'bank' => $this->bank,
+            'branch_number' => $this->branch_number,
+            'branch_check_digit' => $this->branch_check_digit,
+            'account_number' => $this->account_number,
+            'account_check_digit' => $this->account_check_digit,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/ManagingPartnerDTO.php
+++ b/src/DTOs/Recipients/ManagingPartnerDTO.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class ManagingPartnerDTO
+{
+    /**
+     * @param  PhoneNumberDTO[]  $phone_numbers
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $email,
+        public readonly string $document,
+        public readonly string $type, // "individual"
+        public readonly string $mother_name,
+        public readonly string $birthdate,
+        public readonly int $monthly_income,
+        public readonly string $professional_occupation,
+        public readonly bool $self_declared_legal_representative,
+        public readonly AddressDTO $address,
+        public readonly array $phone_numbers,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'],
+            email: $data['email'],
+            document: $data['document'],
+            type: $data['type'],
+            mother_name: $data['mother_name'],
+            birthdate: $data['birthdate'],
+            monthly_income: $data['monthly_income'],
+            professional_occupation: $data['professional_occupation'],
+            self_declared_legal_representative: (bool) $data['self_declared_legal_representative'],
+            address: AddressDTO::fromArray($data['address']),
+            phone_numbers: array_map(fn ($p) => PhoneNumberDTO::fromArray($p), $data['phone_numbers']),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'email' => $this->email,
+            'document' => $this->document,
+            'type' => $this->type,
+            'mother_name' => $this->mother_name,
+            'birthdate' => $this->birthdate,
+            'monthly_income' => $this->monthly_income,
+            'professional_occupation' => $this->professional_occupation,
+            'self_declared_legal_representative' => $this->self_declared_legal_representative,
+            'address' => $this->address->toArray(),
+            'phone_numbers' => array_map(fn ($pn) => $pn->toArray(), $this->phone_numbers),
+        ];
+    }
+}

--- a/src/DTOs/Recipients/PhoneNumberDTO.php
+++ b/src/DTOs/Recipients/PhoneNumberDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class PhoneNumberDTO
+{
+    public function __construct(
+        public readonly string $ddd,
+        public readonly string $number,
+        public readonly string $type,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            ddd: $data['ddd'],
+            number: $data['number'],
+            type: $data['type'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'ddd' => $this->ddd,
+            'number' => $this->number,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/RecipientPFDTO.php
+++ b/src/DTOs/Recipients/RecipientPFDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class RecipientPFDTO
+{
+    public function __construct(
+        public readonly RegisterInformationPFDTO $register_information,
+        public readonly BankAccountDTO $default_bank_account,
+        public readonly TransferSettingsDTO $transfer_settings,
+        public readonly AutomaticAnticipationSettingsDTO $automatic_anticipation_settings,
+        public readonly string $code,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            register_information: RegisterInformationPFDTO::fromArray($data['register_information']),
+            default_bank_account: BankAccountDTO::fromArray($data['default_bank_account']),
+            transfer_settings: TransferSettingsDTO::fromArray($data['transfer_settings']),
+            automatic_anticipation_settings: AutomaticAnticipationSettingsDTO::fromArray($data['automatic_anticipation_settings']),
+            code: $data['code'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'register_information' => $this->register_information->toArray(),
+            'default_bank_account' => $this->default_bank_account->toArray(),
+            'transfer_settings' => $this->transfer_settings->toArray(),
+            'automatic_anticipation_settings' => $this->automatic_anticipation_settings->toArray(),
+            'code' => $this->code,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/RecipientPJDTO.php
+++ b/src/DTOs/Recipients/RecipientPJDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class RecipientPJDTO
+{
+    public function __construct(
+        public readonly RegisterInformationPJDTO $register_information,
+        public readonly BankAccountDTO $default_bank_account,
+        public readonly TransferSettingsDTO $transfer_settings,
+        public readonly AutomaticAnticipationSettingsDTO $automatic_anticipation_settings,
+        public readonly string $code,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            register_information: RegisterInformationPJDTO::fromArray($data['register_information']),
+            default_bank_account: BankAccountDTO::fromArray($data['default_bank_account']),
+            transfer_settings: TransferSettingsDTO::fromArray($data['transfer_settings']),
+            automatic_anticipation_settings: AutomaticAnticipationSettingsDTO::fromArray($data['automatic_anticipation_settings']),
+            code: $data['code'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'register_information' => $this->register_information->toArray(),
+            'default_bank_account' => $this->default_bank_account->toArray(),
+            'transfer_settings' => $this->transfer_settings->toArray(),
+            'automatic_anticipation_settings' => $this->automatic_anticipation_settings->toArray(),
+            'code' => $this->code,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/RegisterInformationPFDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPFDTO.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class RegisterInformationPFDTO
+{
+    /**
+     * @param  PhoneNumberDTO[]  $phone_numbers
+     */
+    public function __construct(
+        public readonly array $phone_numbers,
+        public readonly AddressDTO $address,
+        public readonly string $name,
+        public readonly string $email,
+        public readonly string $document,
+        public readonly string $type, // "individual"
+        public readonly string $site_url,
+        public readonly string $mother_name,
+        public readonly string $birthdate,
+        public readonly int $monthly_income,
+        public readonly string $professional_occupation,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            phone_numbers: array_map(fn ($p) => PhoneNumberDTO::fromArray($p), $data['phone_numbers']),
+            address: AddressDTO::fromArray($data['address']),
+            name: $data['name'],
+            email: $data['email'],
+            document: $data['document'],
+            type: $data['type'],
+            site_url: $data['site_url'],
+            mother_name: $data['mother_name'],
+            birthdate: $data['birthdate'],
+            monthly_income: $data['monthly_income'],
+            professional_occupation: $data['professional_occupation'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'phone_numbers' => array_map(fn ($pn) => $pn->toArray(), $this->phone_numbers),
+            'address' => $this->address->toArray(),
+            'name' => $this->name,
+            'email' => $this->email,
+            'document' => $this->document,
+            'type' => $this->type,
+            'site_url' => $this->site_url,
+            'mother_name' => $this->mother_name,
+            'birthdate' => $this->birthdate,
+            'monthly_income' => $this->monthly_income,
+            'professional_occupation' => $this->professional_occupation,
+        ];
+    }
+}

--- a/src/DTOs/Recipients/RegisterInformationPJDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPJDTO.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class RegisterInformationPJDTO
+{
+    /**
+     * @param  PhoneNumberDTO[]  $phone_numbers
+     * @param  ManagingPartnerDTO[]  $managing_partners
+     */
+    public function __construct(
+        public readonly array $phone_numbers,
+        public readonly AddressDTO $main_address,
+        public readonly string $company_name,
+        public readonly string $trading_name,
+        public readonly string $email,
+        public readonly string $document,
+        public readonly string $type, // "corporation"
+        public readonly string $site_url,
+        public readonly int $annual_revenue,
+        public readonly string $corporation_type,
+        public readonly string $founding_date,
+        public readonly array $managing_partners,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            phone_numbers: array_map(fn ($p) => PhoneNumberDTO::fromArray($p), $data['phone_numbers']),
+            main_address: AddressDTO::fromArray($data['main_address']),
+            company_name: $data['company_name'],
+            trading_name: $data['trading_name'],
+            email: $data['email'],
+            document: $data['document'],
+            type: $data['type'],
+            site_url: $data['site_url'],
+            annual_revenue: $data['annual_revenue'],
+            corporation_type: $data['corporation_type'],
+            founding_date: $data['founding_date'],
+            managing_partners: array_map(fn ($mp) => ManagingPartnerDTO::fromArray($mp), $data['managing_partners']),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'phone_numbers' => array_map(fn ($pn) => $pn->toArray(), $this->phone_numbers),
+            'address' => $this->main_address->toArray(),
+            'company_name' => $this->company_name,
+            'email' => $this->email,
+            'document' => $this->document,
+            'type' => $this->type,
+            'site_url' => $this->site_url,
+            'trading_name' => $this->trading_name,
+            'annual_revenue' => $this->annual_revenue,
+            'corporation_type' => $this->corporation_type,
+            'founding_date' => $this->founding_date,
+            'managing_partners' => array_map(fn ($mp) => $mp->toArray(), $this->managing_partners),
+        ];
+    }
+}

--- a/src/DTOs/Recipients/TransferSettingsDTO.php
+++ b/src/DTOs/Recipients/TransferSettingsDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Payments\Pagarme\DTOs;
+
+class TransferSettingsDTO
+{
+    public function __construct(
+        public readonly bool $transfer_enabled,
+        public readonly string $transfer_interval,
+        public readonly int $transfer_day,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            transfer_enabled: filter_var($data['transfer_enabled'], FILTER_VALIDATE_BOOLEAN),
+            transfer_interval: $data['transfer_interval'],
+            transfer_day: $data['transfer_day'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'transfer_enabled' => $this->transfer_enabled,
+            'transfer_interval' => $this->transfer_interval,
+            'transfer_day' => $this->transfer_day,
+        ];
+    }
+}

--- a/src/Endpoints/Recipient.php
+++ b/src/Endpoints/Recipient.php
@@ -25,4 +25,9 @@ class Recipient extends ApiAdapter
     {
         return $this->get('recipients');
     }
+
+    public function kycLink($id)
+    {
+        return $this->post("recipients/{$id}/kyc_link", []);
+    }
 }


### PR DESCRIPTION
Surgiu a necessidade de utilizar o endpoint de prova de vida dos recebedores, por isso a funcionalidade foi adicionada ao respectivo endpoint.

Durante a criação de novos recebedores, observou-se que era necessário um data transfer object para garantir que o payload da requisição fosse montado conforme o esperado.

Foram criados DTOs que abrangem o escopo de criação de recebedores, com a capacidade de serem instanciados a partir de um array, o que facilita sua utilização. Além disso, como as funções dos endpoints sempre esperam um array como payload, foi adicionada a funcionalidade de retornar o conteúdo em formato de array, garantindo compatibilidade com as funcionalidades já existentes.