### PR TITLE
Corrigindo namespaces errados dos DTOs

### DIFF
--- a/src/DTOs/Recipients/AddressDTO.php
+++ b/src/DTOs/Recipients/AddressDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class AddressDTO
 {

--- a/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
+++ b/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class AutomaticAnticipationSettingsDTO
 {

--- a/src/DTOs/Recipients/BankAccountDTO.php
+++ b/src/DTOs/Recipients/BankAccountDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class BankAccountDTO
 {

--- a/src/DTOs/Recipients/ManagingPartnerDTO.php
+++ b/src/DTOs/Recipients/ManagingPartnerDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class ManagingPartnerDTO
 {

--- a/src/DTOs/Recipients/PhoneNumberDTO.php
+++ b/src/DTOs/Recipients/PhoneNumberDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class PhoneNumberDTO
 {

--- a/src/DTOs/Recipients/RecipientPFDTO.php
+++ b/src/DTOs/Recipients/RecipientPFDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class RecipientPFDTO
 {

--- a/src/DTOs/Recipients/RecipientPJDTO.php
+++ b/src/DTOs/Recipients/RecipientPJDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class RecipientPJDTO
 {

--- a/src/DTOs/Recipients/RegisterInformationPFDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPFDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class RegisterInformationPFDTO
 {

--- a/src/DTOs/Recipients/RegisterInformationPJDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPJDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class RegisterInformationPJDTO
 {

--- a/src/DTOs/Recipients/TransferSettingsDTO.php
+++ b/src/DTOs/Recipients/TransferSettingsDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Payments\Pagarme\DTOs;
+namespace Dougwn\Pagarme\DTOs\Recipients;
 
 class TransferSettingsDTO
 {


### PR DESCRIPTION
Os DTOs estão com namespace errado, não coincidindo com o padrão do projeto. Foi ajustado e testado, para garantir o funcionamento adequado.