### PR TITLE
FIX DTO RECIPIENTS

### DIFF
--- a/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
+++ b/src/DTOs/Recipients/AutomaticAnticipationSettingsDTO.php
@@ -17,17 +17,17 @@ class AutomaticAnticipationSettingsDTO
             enabled: filter_var($data['enabled'], FILTER_VALIDATE_BOOLEAN),
             type: $data['type'],
             volume_percentage: $data['volume_percentage'],
-            delay: $data['delay'] !== 'null' ? $data['delay'] : null,
+            delay: $data['delay'] ?? null,
         );
     }
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'enabled' => $this->enabled,
             'type' => $this->type,
             'volume_percentage' => $this->volume_percentage,
             'delay' => $this->delay,
-        ];
+        ], fn ($value) => !is_null($value));
     }
 }

--- a/src/DTOs/Recipients/RegisterInformationPFDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPFDTO.php
@@ -14,7 +14,7 @@ class RegisterInformationPFDTO
         public readonly string $email,
         public readonly string $document,
         public readonly string $type, // "individual"
-        public readonly string $site_url,
+        public readonly ?string $site_url,
         public readonly string $mother_name,
         public readonly string $birthdate,
         public readonly int $monthly_income,
@@ -30,7 +30,7 @@ class RegisterInformationPFDTO
             email: $data['email'],
             document: $data['document'],
             type: $data['type'],
-            site_url: $data['site_url'],
+            site_url: $data['site_url'] ?? null,
             mother_name: $data['mother_name'],
             birthdate: $data['birthdate'],
             monthly_income: $data['monthly_income'],
@@ -40,7 +40,7 @@ class RegisterInformationPFDTO
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'phone_numbers' => array_map(fn ($pn) => $pn->toArray(), $this->phone_numbers),
             'address' => $this->address->toArray(),
             'name' => $this->name,
@@ -52,6 +52,6 @@ class RegisterInformationPFDTO
             'birthdate' => $this->birthdate,
             'monthly_income' => $this->monthly_income,
             'professional_occupation' => $this->professional_occupation,
-        ];
+        ], fn ($value) => !is_null($value));
     }
 }

--- a/src/DTOs/Recipients/RegisterInformationPJDTO.php
+++ b/src/DTOs/Recipients/RegisterInformationPJDTO.php
@@ -16,10 +16,10 @@ class RegisterInformationPJDTO
         public readonly string $email,
         public readonly string $document,
         public readonly string $type, // "corporation"
-        public readonly string $site_url,
+        public readonly ?string $site_url,
         public readonly int $annual_revenue,
-        public readonly string $corporation_type,
-        public readonly string $founding_date,
+        public readonly ?string $corporation_type,
+        public readonly ?string $founding_date,
         public readonly array $managing_partners,
     ) {}
 
@@ -33,19 +33,19 @@ class RegisterInformationPJDTO
             email: $data['email'],
             document: $data['document'],
             type: $data['type'],
-            site_url: $data['site_url'],
+            site_url: $data['site_url'] ?? null,
             annual_revenue: $data['annual_revenue'],
-            corporation_type: $data['corporation_type'],
-            founding_date: $data['founding_date'],
+            corporation_type: $data['corporation_type'] ?? null,
+            founding_date: $data['founding_date'] ?? null,
             managing_partners: array_map(fn ($mp) => ManagingPartnerDTO::fromArray($mp), $data['managing_partners']),
         );
     }
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'phone_numbers' => array_map(fn ($pn) => $pn->toArray(), $this->phone_numbers),
-            'address' => $this->main_address->toArray(),
+            'main_address' => $this->main_address->toArray(),
             'company_name' => $this->company_name,
             'email' => $this->email,
             'document' => $this->document,
@@ -56,6 +56,6 @@ class RegisterInformationPJDTO
             'corporation_type' => $this->corporation_type,
             'founding_date' => $this->founding_date,
             'managing_partners' => array_map(fn ($mp) => $mp->toArray(), $this->managing_partners),
-        ];
+        ], fn ($value) => !is_null($value));
     }
 }


### PR DESCRIPTION
Ajustado DTO dos recebedores, para tornar opcional alguns parâmetros, e removê-los do payloado quando nulo.

Esse ajuste foi necessário pois os parâmetros nulaveis não devem ser enviados quando for nulo, a api esta fortemente tipado, assim, responde como se estivesse enviado o valor errado, quando null.